### PR TITLE
Add EmberData to the dictionary

### DIFF
--- a/index.dic
+++ b/index.dic
@@ -56,6 +56,7 @@ ESLint
 EmbeddedRecordsMixin
 Ember
 EmberApp
+EmberData
 Ember_Observer
 EmbeddedRecordMixin
 ember-qunit


### PR DESCRIPTION
The project has decided to standardize on EmberData instead of Ember Data. Examples are on [this API page for EmberData](https://api.emberjs.com/ember-data/release/modules/ember-data-overview?show=inherited).

I added EmberData to the local project config, but thought maybe this was common enough to be upstreamed too.